### PR TITLE
[TOOLS-1530] add missing line for document additions

### DIFF
--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -162,6 +162,11 @@ func (report *HumanReport) generateHumanDetailOutputAddition(detail Detail) (str
 	var output bytes.Buffer
 
 	switch detail.To.Kind {
+	case yamlv3.DocumentNode:
+		_, _ = fmt.Fprint(&output, yellow("%c %s added:\n",
+			ADDITION,
+			text.Plural(len(detail.To.Content), "document"),
+		))
 	case yamlv3.SequenceNode:
 		_, _ = output.WriteString(yellow("%c %s added:\n",
 			ADDITION,


### PR DESCRIPTION
There is a missing `case` in a `switch` for generating a header, when adding a new document.

Before the change:
<img width="792" alt="Screenshot 2024-01-15 at 20 47 11" src="https://github.com/UnderTechnologies/dyff/assets/104995572/882f9ce0-cdeb-4954-8959-1baaab98fbea">

After the change:
<img width="808" alt="Screenshot 2024-01-15 at 20 47 39" src="https://github.com/UnderTechnologies/dyff/assets/104995572/54fdb50a-2d4b-4d74-b138-2f43cd1b35eb">
